### PR TITLE
use webmock instead of solr_wrapper

### DIFF
--- a/rsolr.gemspec
+++ b/rsolr.gemspec
@@ -41,5 +41,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rdoc', '>= 4.0'
   s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'simplecov'
-  s.add_development_dependency 'solr_wrapper'
+  s.add_development_dependency 'webmock'
 end

--- a/spec/integration/solr5_spec.rb
+++ b/spec/integration/solr5_spec.rb
@@ -1,19 +1,16 @@
 require 'spec_helper'
-require 'solr_wrapper'
+require 'webmock/rspec'
 
 RSpec.describe "Solr basic_configs" do
-  SOLR_INSTANCE =  SolrWrapper.default_instance({})
-  before(:all) { SOLR_INSTANCE.start }
-  after(:all) { SOLR_INSTANCE.stop }
 
   context "basic configs" do
-    subject { RSolr.connect url: "http://localhost:#{SOLR_INSTANCE.port}/solr/basic_configs/"}
-    around(:each) do |example|
-      SOLR_INSTANCE.with_collection(name: "basic_configs", dir: File.join(FIXTURES_DIR, "basic_configs")) do |coll|
-        example.run
-      end
+    subject { RSolr.connect url: "http://localhost:8983/solr/basic_configs/"}
+    before(:each) do
+      stub_request(:head, %r{localhost:8983}).to_return(status: 200, body: "", headers: {})
+
     end
-    describe "HEAD admin/ping" do
+    
+describe "HEAD admin/ping" do
       it "should not raise an exception" do
         expect { subject.head('admin/ping') }.not_to raise_error
       end
@@ -25,6 +22,9 @@ RSpec.describe "Solr basic_configs" do
   end
 
   context "error handling" do
+    before(:all) do
+        stub_request(:any, %r{localhost:65432}).to_raise(Errno::ECONNREFUSED)
+    end
     subject { RSolr.connect url: "http://localhost:65432/solr/basic_configs/"}
 
     it "wraps connection errors" do


### PR DESCRIPTION
Integration tests used `solr_wrapper` but don't really depend on having a live Solr instance for the tests, so let's mock the responses instead.